### PR TITLE
Implement lower and upper functions

### DIFF
--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -4,6 +4,7 @@ mod count;
 mod row_number;
 mod sum;
 mod lower;
+mod upper;
 
 pub use aggregate_to_string::*;
 pub use average::*;
@@ -11,6 +12,7 @@ pub use count::*;
 pub use row_number::*;
 pub use sum::*;
 pub use lower::*;
+pub use upper::*;
 
 use super::{Aliasable, Expression};
 use std::borrow::Cow;
@@ -31,6 +33,7 @@ pub(crate) enum FunctionType<'a> {
     Average(Average<'a>),
     Sum(Sum<'a>),
     Lower(Lower<'a>),
+    Upper(Upper<'a>),
 }
 
 impl<'a> Aliasable<'a> for Function<'a> {
@@ -45,4 +48,4 @@ impl<'a> Aliasable<'a> for Function<'a> {
     }
 }
 
-function!(RowNumber, Count, AggregateToString, Average, Sum, Lower);
+function!(RowNumber, Count, AggregateToString, Average, Sum, Lower, Upper);

--- a/src/ast/function/upper.rs
+++ b/src/ast/function/upper.rs
@@ -2,26 +2,26 @@ use super::Function;
 use crate::ast::Expression;
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Lower<'a> {
+pub struct Upper<'a> {
     pub(crate) expression: Box<Expression<'a>>,
 }
 
-/// Converts the result of the expression into lowercase string.
+/// Converts the result of the expression into uppercase string.
 ///
 /// ```rust
 /// # use quaint::{ast::*, visitor::{Visitor, Sqlite}};
 /// # fn main() -> Result<(), quaint::error::Error> {
-/// let query = Select::from_table("users").value(lower(Column::from("name")));
+/// let query = Select::from_table("users").value(upper(Column::from("name")));
 /// let (sql, _) = Sqlite::build(query)?;
-/// assert_eq!("SELECT LOWER(`name`) FROM `users`", sql);
+/// assert_eq!("SELECT UPPER(`name`) FROM `users`", sql);
 /// # Ok(())
 /// # }
 /// ```
-pub fn lower<'a, E>(expression: E) -> Function<'a>
+pub fn upper<'a, E>(expression: E) -> Function<'a>
 where
     E: Into<Expression<'a>>,
 {
-    let fun = Lower {
+    let fun = Upper {
         expression: Box::new(expression.into()),
     };
 

--- a/src/connector/mssql.rs
+++ b/src/connector/mssql.rs
@@ -1853,4 +1853,28 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn upper_fun() {
+        let conn = single::Quaint::new(&CONN_STR).await.unwrap();
+        let select = Select::default().value(upper("foo").alias("val"));
+
+        let res = conn.query(select.into()).await.unwrap();
+        let row = res.get(0).unwrap();
+        let val = row.get("val").unwrap().as_str();
+
+        assert_eq!(Some("FOO"), val);
+    }
+
+    #[tokio::test]
+    async fn lower_fun() {
+        let conn = single::Quaint::new(&CONN_STR).await.unwrap();
+        let select = Select::default().value(lower("BAR").alias("val"));
+
+        let res = conn.query(select.into()).await.unwrap();
+        let row = res.get(0).unwrap();
+        let val = row.get("val").unwrap().as_str();
+
+        assert_eq!(Some("bar"), val);
+    }
 }

--- a/src/connector/mysql.rs
+++ b/src/connector/mysql.rs
@@ -964,4 +964,28 @@ VALUES (1, 'Joe', 27, 20000.00 );
             assert_eq!(result.get(0).unwrap().get("id").unwrap(), &Value::Integer(Some(2)))
         }
     }
+
+    #[tokio::test]
+    async fn upper_fun() {
+        let conn = Quaint::new(&CONN_STR).await.unwrap();
+        let select = Select::default().value(upper("foo").alias("val"));
+
+        let res = conn.query(select.into()).await.unwrap();
+        let row = res.get(0).unwrap();
+        let val = row.get("val").unwrap().as_str();
+
+        assert_eq!(Some("FOO"), val);
+    }
+
+    #[tokio::test]
+    async fn lower_fun() {
+        let conn = Quaint::new(&CONN_STR).await.unwrap();
+        let select = Select::default().value(lower("BAR").alias("val"));
+
+        let res = conn.query(select.into()).await.unwrap();
+        let row = res.get(0).unwrap();
+        let val = row.get("val").unwrap().as_str();
+
+        assert_eq!(Some("bar"), val);
+    }
 }

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -1167,4 +1167,28 @@ mod tests {
             assert_eq!(result.get(0).unwrap().get("id").unwrap(), &Value::integer(2))
         }
     }
+
+    #[tokio::test]
+    async fn upper_fun() {
+        let conn = Quaint::new(&CONN_STR).await.unwrap();
+        let select = Select::default().value(upper("foo").alias("val"));
+
+        let res = conn.query(select.into()).await.unwrap();
+        let row = res.get(0).unwrap();
+        let val = row.get("val").unwrap().as_str();
+
+        assert_eq!(Some("FOO"), val);
+    }
+
+    #[tokio::test]
+    async fn lower_fun() {
+        let conn = Quaint::new(&CONN_STR).await.unwrap();
+        let select = Select::default().value(lower("BAR").alias("val"));
+
+        let res = conn.query(select.into()).await.unwrap();
+        let row = res.get(0).unwrap();
+        let val = row.get("val").unwrap().as_str();
+
+        assert_eq!(Some("bar"), val);
+    }
 }

--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -535,4 +535,28 @@ mod tests {
             _ => panic!(err),
         }
     }
+
+    #[tokio::test]
+    async fn upper_fun() {
+        let conn = Sqlite::try_from("file:db/test.db").unwrap();
+        let select = Select::default().value(upper("foo").alias("val"));
+
+        let res = conn.query(select.into()).await.unwrap();
+        let row = res.get(0).unwrap();
+        let val = row.get("val").unwrap().as_str();
+
+        assert_eq!(Some("FOO"), val);
+    }
+
+    #[tokio::test]
+    async fn lower_fun() {
+        let conn = Sqlite::try_from("file:db/test.db").unwrap();
+        let select = Select::default().value(lower("BAR").alias("val"));
+
+        let res = conn.query(select.into()).await.unwrap();
+        let row = res.get(0).unwrap();
+        let val = row.get("val").unwrap().as_str();
+
+        assert_eq!(Some("bar"), val);
+    }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -813,7 +813,11 @@ pub trait Visitor<'a> {
             }
             FunctionType::Lower(lower) => {
                 self.write("LOWER")?;
-                self.surround_with("(", ")", |ref mut s| s.visit_column(lower.column))?;
+                self.surround_with("(", ")", |ref mut s| s.visit_expression(*lower.expression))?;
+            }
+            FunctionType::Upper(upper) => {
+                self.write("UPPER")?;
+                self.surround_with("(", ")", |ref mut s| s.visit_expression(*upper.expression))?;
             }
         };
 


### PR DESCRIPTION
Lower should take `Expression` so we can use it for non-column values too.

And it's nice to have `Upper` too. Tests included for all supported databases.

With these changes we can merge!